### PR TITLE
Fix extraneous semicolons

### DIFF
--- a/common/cl_parse.c
+++ b/common/cl_parse.c
@@ -918,7 +918,7 @@ void CL_ParseServerMessage (void)
 			i = MSG_ReadByte ();
 			if (i < 0 || i >= MAX_CL_STATS)
 				Sys_Error ("svc_updatestat: %i is invalid", i);
-			cl.stats[i] = MSG_ReadLong ();;
+                       cl.stats[i] = MSG_ReadLong ();
 			break;
 			
 		case svc_spawnstaticsound:

--- a/common/net_wipx.c
+++ b/common/net_wipx.c
@@ -179,7 +179,7 @@ int WIPX_OpenSocket (int port)
 
 	address.sa_family = AF_IPX;
 	memset(address.sa_netnum, 0, 4);
-	memset(address.sa_nodenum, 0, 6);;
+       memset(address.sa_nodenum, 0, 6);
 	address.sa_socket = htons((unsigned short)port);
 	if( bind (newsocket, (void *)&address, sizeof(address)) == 0)
 	{

--- a/common/snd_win.c
+++ b/common/snd_win.c
@@ -570,7 +570,7 @@ int SNDDMA_Init(void)
 	{
 		if (snd_firsttime || snd_isdirect)
 		{
-			stat = SNDDMA_InitDirect ();;
+                       stat = SNDDMA_InitDirect ();
 
 			if (stat == SIS_SUCCESS)
 			{


### PR DESCRIPTION
## Summary
- remove stray semicolons that produced empty statements in `net_wipx.c`, `cl_parse.c` and `snd_win.c`

## Testing
- `make -f Makefile.Linux` *(fails: No rule to make target 'targets')*

------
https://chatgpt.com/codex/tasks/task_e_684580b002ec832b9113685581461f54